### PR TITLE
Disable VSync on a Wayland session

### DIFF
--- a/vitamins/run.sh
+++ b/vitamins/run.sh
@@ -7,7 +7,7 @@ socat $SOCAT_ARGS \
 socat_pid=$!
 
 if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
- FLAGS="--enable-features=WaylandWindowDecorations,UseOzonePlatform,UseSkiaRenderer --ozone-platform=wayland --enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization"
+ FLAGS="--enable-features=WaylandWindowDecorations,UseOzonePlatform,UseSkiaRenderer --ozone-platform=wayland --enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --disable-gpu-vsync --disable-frame-rate-limit"
 else
  FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer'
 fi


### PR DESCRIPTION
Ozone currently is incapable of reading the monitors set refresh rate and will always default to 60hz. This will result in a sluggish stuttery scrolling experience on high refresh rate monitors (like on 165HZ). Disabling VSync will bypass their default 60HZ setting and thanks to Wayland itself being somewhat of a VSync, the window will still be restricted the correct refreshrate restoring the smooth 165Hz scrolling experience.

Keep in mind this is a workaround and in no means the correct fix, however a still worthwhile workaround in my opinion.