### PR TITLE
meta: update link to the localization files.

### DIFF
--- a/vitamins/io.github.spacingbat3.webcord.metainfo.xml
+++ b/vitamins/io.github.spacingbat3.webcord.metainfo.xml
@@ -292,5 +292,5 @@
 
   <url type="homepage">https://github.com/SpacingBat3/WebCord</url>
   <url type="bugtracker">https://github.com/SpacingBat3/WebCord/issues</url>
-  <url type="translate">https://github.com/SpacingBat3/WebCord/blob/master/docs/Translate.md</url>
+  <url type="translate">https://hosted.weblate.org/engage/webcord/</url>
 </component>


### PR DESCRIPTION
Tiny fix that corrects the path to the localization files so it uses an URL to official Weblate instance.

Resolves issue reported at WebCord's bug tracker: https://github.com/SpacingBat3/WebCord/issues/301.