### PR TITLE
Add permission to support global menu

### DIFF
--- a/io.github.spacingbat3.webcord.yml
+++ b/io.github.spacingbat3.webcord.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --device=all
+  - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierItem-2-1


### PR DESCRIPTION
Global Menu is the globally-shared menu bar of all applications launched in your desktop session. This functionality is available in matte and KDE. An example is available in this video: https://www.youtube.com/watch?v=Tqt9iotv7y8