### PR TITLE
Added user command and fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A Discord and Fosscord client implemented directly without Discord API. Made in 
 ## Use global menu
 To make WebCord work with the global menu you have to give the flatpak access to `com.canonical.AppMenu.Registrar`, this can be done with
 ```
-flatpak override --talk-name=com.canonical.AppMenu.Registrar io.github.spacingbat3.webcord
+flatpak override --user --talk-name=com.canonical.AppMenu.Registrar io.github.spacingbat3.webcord
 ```
 or using flatseal
 
 ## Fix tray icon
 Since WebCord release 3.10.1, electron uses a different way to display the tray icon, which requires this flatpak to have the `--own-name==org.kde.StatusNotifierItem-3-1` permission, this command adds the permission:
 ```
-flatpak override --own-name==org.kde.StatusNotifierItem-3-1 io.github.spacingbat3.webcord
+flatpak override --user --own-name=org.kde.StatusNotifierItem-3-1 io.github.spacingbat3.webcord
 ```


### PR DESCRIPTION
```
flatpak override --own-name=org.kde.StatusNotifierItem-3-1 io.github.spacingbat3.webcord
```
says
```
error: Permission denied
```

with --user it works