### PR TITLE
Fix typo in command that fixes tray icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ flatpak override --talk-name=com.canonical.AppMenu.Registrar io.github.spacingba
 or using flatseal
 
 ## Fix tray icon
-Since WebCord release 3.10.1, electron uses a different way to display the tray icon, which requires this flatpak to have the `--own-name==org.kde.StatusNotifierItem-3-1` permission, this command adds the permission:
+Since WebCord release 3.10.1, electron uses a different way to display the tray icon, which requires this flatpak to have the `--own-name=org.kde.StatusNotifierItem-3-1` permission, this command adds the permission:
 ```
-flatpak override --own-name==org.kde.StatusNotifierItem-3-1 io.github.spacingbat3.webcord
+flatpak override --own-name=org.kde.StatusNotifierItem-3-1 io.github.spacingbat3.webcord
 ```


### PR DESCRIPTION
Removed extra = that causes command to not work.