### PR TITLE
Add workaround for UncaughtException

### DIFF
--- a/vitamins/run.sh
+++ b/vitamins/run.sh
@@ -6,4 +6,13 @@ then
     FLAGS="$FLAGS --disable-gpu-sandbox"
 fi
 
+# This deletes the windowState file when it contains 0 bytes.
+# Works around https://github.com/flathub/io.github.spacingbat3.webcord/issues/37
+WINDOWSTATE="$XDG_CONFIG_HOME/WebCord/windowState"
+if [[ -f "$WINDOWSTATE" ]]; then
+    if [[ $(wc -c "$WINDOWSTATE" | cut -d' ' -f1) == 0 ]]; then
+        rm "$WINDOWSTATE"
+    fi
+fi
+
 env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.github.spacingbat3.webcord}" zypak-wrapper /app/bin/webcord/usr/bin/webcord $FLAGS "$@"


### PR DESCRIPTION
This works around https://github.com/flathub/io.github.spacingbat3.webcord/issues/37 by deleting the `workState` file whenever `wc -c` reports `0` (bytes). The user *theoretically* shouldn't run into this issue anymore.