### PR TITLE
fix: missing decorations on pop_os using wayland

### DIFF
--- a/vitamins/run.sh
+++ b/vitamins/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer --ozone-platform-hint=auto'
 
-if [[ $XDG_SESSION_TYPE == "wayland" && $XDG_CURRENT_DESKTOP == "GNOME" ]]
+if [[ $XDG_SESSION_TYPE == "wayland" && $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
 then
     FLAGS="$FLAGS --enable-features=WaylandWindowDecorations"
 fi


### PR DESCRIPTION
on pop os, XDG_CURRENT_DESKTOP is setted to `pop:GNOME`, because of that, window decoration are not been rendered, this should fix it.
![image](https://github.com/flathub/io.github.spacingbat3.webcord/assets/3910403/7ff95662-d8d9-4ab3-85b3-e3fd7d58a30b)

before fix:
![image](https://github.com/flathub/io.github.spacingbat3.webcord/assets/3910403/d82e4f4f-eacf-4f6e-bd8f-3f01546b1408)

after fix:
![image](https://github.com/flathub/io.github.spacingbat3.webcord/assets/3910403/96c3e8aa-0eea-41a1-a4c5-7e530f694356)


