### PR TITLE
Allow user to disable wayland by revoking permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ Since WebCord release 3.10.1, electron uses a different way to display the tray 
 ```
 flatpak override --own-name=org.kde.StatusNotifierItem-3-1 io.github.spacingbat3.webcord
 ```
+## Run under XWayland
+If using wayland, WebCord will automatically run under wayland. If this is not desired, WebCord can be forced to use XWayland by revoking the Wayland permissions:
+```
+flatpak override --user --nosocket=wayland --nosocket=x11-fallback --socket=x11 io.github.spacingbat3.webcord
+```

--- a/vitamins/run.sh
+++ b/vitamins/run.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
-FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer --ozone-platform-hint=auto'
+FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer'
 
-if [[ $XDG_SESSION_TYPE == "wayland" && $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
-then
-    FLAGS="$FLAGS --enable-features=WaylandWindowDecorations"
-fi
+WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 
-if [[ $XDG_SESSION_TYPE =~ "[Ww]ayland" ]] && [ -c /dev/nvidia0 ]
+if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" ]]
 then
-    FLAGS="$FLAGS --disable-gpu-sandbox"
+    FLAGS="$FLAGS --ozone-platform-hint=auto"
+
+    if [[ $XDG_SESSION_TYPE == "wayland" && $XDG_CURRENT_DESKTOP == *"GNOME"* ]]
+    then
+            FLAGS="$FLAGS --enable-features=WaylandWindowDecorations"
+    fi
+
+    if [[ $XDG_SESSION_TYPE =~ "[Ww]ayland" ]] && [ -c /dev/nvidia0 ]
+    then
+        FLAGS="$FLAGS --disable-gpu-sandbox"
+    fi
 fi
 
 # This deletes the windowState file when it contains 0 bytes.


### PR DESCRIPTION
Allows users to opt out of wayland by simply revoking wayland permissions for webcord.

"Fix" for #52 and #45