### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ flatpak override --own-name=org.kde.StatusNotifierItem-3-1 io.github.spacingbat3
 ## Run under XWayland
 If using wayland, WebCord will automatically run under wayland. If this is not desired, WebCord can be forced to use XWayland by revoking the Wayland permissions:
 ```
-flatpak override --user --nosocket=wayland --nosocket=x11-fallback --socket=x11 io.github.spacingbat3.webcord
+flatpak override --user --nosocket=wayland --nosocket=fallback-x11 --socket=x11 io.github.spacingbat3.webcord
 ```


### PR DESCRIPTION
Fixes: Error: unknown socket type x11-fallback, allowed types are: x11, wayland, pulseaudio, session-bus, system-bus, fallback-x11, ssh-auth, pcsc, cups, gpg-agent.