### PR TITLE
Remove tray icon fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@ flatpak override --talk-name=com.canonical.AppMenu.Registrar io.github.spacingba
 ```
 or using flatseal
 
-## Fix tray icon
-Since WebCord release 3.10.1, electron uses a different way to display the tray icon, which requires this flatpak to have the `--own-name=org.kde.StatusNotifierItem-3-1` permission, this command adds the permission:
-```
-flatpak override --own-name=org.kde.StatusNotifierItem-3-1 io.github.spacingbat3.webcord
-```
 ## Run under XWayland
 If using wayland, WebCord will automatically run under wayland. If this is not desired, WebCord can be forced to use XWayland by revoking the Wayland permissions:
 ```


### PR DESCRIPTION
webcord seems to work with tray icons since 4.4.0 (or already 4.3.0), making the tray icon fix in the readme useless

closes #27 