### PR TITLE
Enable support for Wayland IME (for non-latin text entry)

### DIFF
--- a/vitamins/run.sh
+++ b/vitamins/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer'
+FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer --enable-wayland-ime'
 
 WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 


### PR DESCRIPTION
added `--enable-wayland-ime` to FLAGS
makes fcitx5 work in wayland mode and on xwayland. 

Not tested in actual legacy Xorg but should work too.