### PR TITLE
Make Wayland an _opt-out_ feature (instead of _opt-in_)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,8 @@ flatpak override --talk-name=com.canonical.AppMenu.Registrar io.github.spacingba
 ```
 or using flatseal
 
-## Recommendations
-
-Running the app in a native Wayland context:
+## Run under XWayland
+If using wayland, WebCord will automatically run under wayland. If this is not desired, WebCord can be forced to use XWayland by revoking the Wayland permissions:
 ```
-flatpak run --branch=stable --arch=x86_64 io.github.spacingbat3.webcord --ignore-gpu-blocklist --enable-features=UseOzonePlatform,VaapiVideoDecoder,WebRTCPipeWireCapturer,smooth-scrolling,gpu-rasterization,zero-copy --ozone-platform=wayland
+flatpak override --user --nosocket=wayland --nosocket=fallback-x11 --socket=x11 io.github.spacingbat3.webcord
 ```
-
-> This will make use of the Ozone Platform setting, which comes with a Wayland mode by default.
-> Also added in `WebRTCPipeWireCapturer` to screenshare stuff using Pipewire Web RTC. Just make sure you have the xdg-portals installed properly.

--- a/io.github.spacingbat3.webcord.yml
+++ b/io.github.spacingbat3.webcord.yml
@@ -8,7 +8,8 @@ command: run.sh
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --device=all


### PR DESCRIPTION
Currently WebCord starts in X11 mode even though it's running in a wayland session.
WebCord should default to wayland.

This reverts the commit (31c00a4) that disabled `wayland` per default.