### PR TITLE
Fix wayland detection

### DIFF
--- a/io.github.spacingbat3.webcord.yml
+++ b/io.github.spacingbat3.webcord.yml
@@ -8,7 +8,8 @@ command: run.sh
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   - --device=all

--- a/vitamins/run.sh
+++ b/vitamins/run.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer --enable-wayland-ime'
 
-WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+if [[ -e "$WAYLAND_DISPLAY" ]]
+then
+    WAYLAND_SOCKET=$WAYLAND_DISPLAY
+else
+    WAYLAND_SOCKET=$XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:-"wayland-0"}
+fi
 
-if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" ]]
+if [[ -e "$WAYLAND_SOCKET" ]]
 then
     FLAGS="$FLAGS --ozone-platform-hint=auto"
 


### PR DESCRIPTION
`WAYLAND_DISPLAY` environment variable provides full path to wayland socket in flatpak environment if `--socket=wayland` is enabled. But symlink to `$XDG_RUNTIME_DIR` no longer created seems to be behaviour changes in recent Flatpak 1.15.x. This PR fix wayland detection in `run.sh` that should work for both `$WAYLAND_DISPLAY` and `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY`, so that flags will properly applied.

The PR also re-enabled wayland socket in manifest, since the last disable is about a year ago, I think we should give it a try again.