### PR TITLE
Add XCURSOR_PATH to use host cursor icons

### DIFF
--- a/io.github.spacingbat3.webcord.yml
+++ b/io.github.spacingbat3.webcord.yml
@@ -16,6 +16,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 modules:
   - name: webcord
     buildsystem: simple


### PR DESCRIPTION
Add environment variable `XCURSOR_PATH` to explicitly using host cursors.