### PR TITLE
Fix 4.11.0 launch issue, and some clean up

### DIFF
--- a/io.github.spacingbat3.webcord.yml
+++ b/io.github.spacingbat3.webcord.yml
@@ -2,7 +2,7 @@ app-id: io.github.spacingbat3.webcord
 runtime: org.freedesktop.Platform
 runtime-version: "24.08"
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 sdk: org.freedesktop.Sdk
 command: run.sh
 separate-locales: false
@@ -22,13 +22,13 @@ modules:
     buildsystem: simple
     sources:
       - type: file
-        url: https://github.com/SpacingBat3/WebCord/releases/download/v4.10.4/WebCord-4.10.4-x64.AppImage
-        sha256: 8570eee99ad7b44f8bf876d341f22533e3a3bbb8f46a0855b926711cd1d0c2dd
+        url: https://github.com/SpacingBat3/WebCord/releases/download/v4.11.0/WebCord-4.11.0-x64.AppImage
+        sha256: 6e0dc63237ff43340e6dcfc3ab15dfbc07e0c8eee35a5ece53470a451a33c419
         only-arches: [x86_64]
 
       - type: file
-        url: https://github.com/SpacingBat3/WebCord/releases/download/v4.10.4/WebCord-4.10.4-arm64.AppImage
-        sha256: 0e6f7edd002477b291ea9d9ec63935c10cd6f6f6dafbb7b7b66e1a3a006c3a70
+        url: https://github.com/SpacingBat3/WebCord/releases/download/v4.11.0/WebCord-4.11.0-arm64.AppImage
+        sha256: 5a7274266f33b21b946426cd2f712ca58f9c7a7e410fae4734629f72f24e9b27
         only-arches: [aarch64]
 
       - type: file
@@ -54,5 +54,4 @@ modules:
       - install -D icon256.png /app/share/icons/hicolor/256x256/apps/io.github.spacingbat3.webcord.png
       - chmod +x WebCord-*.AppImage
       - ./WebCord-*.AppImage --appimage-extract
-      - mv squashfs-root /app/bin/webcord
-      - sed 's|exec xargs|exec xargs zypak-wrapper|g' -i /app/bin/webcord/usr/bin/webcord
+      - mv squashfs-root/usr/lib/webcord /app/bin/webcord

--- a/vitamins/io.github.spacingbat3.webcord.metainfo.xml
+++ b/vitamins/io.github.spacingbat3.webcord.metainfo.xml
@@ -44,6 +44,14 @@
   </content_rating>
 
   <releases>
+    <release version="4.11.0" date="2025-05-16" urgency="medium">
+      <description></description>
+      <url>https://github.com/SpacingBat3/WebCord/releases/tag/v4.11.0</url>
+    </release>
+    <release version="4.10.5" date="2025-04-18" urgency="medium">
+      <description></description>
+      <url>https://github.com/SpacingBat3/WebCord/releases/tag/v4.10.5</url>
+    </release>
     <release version="4.10.4" date="2025-02-19" urgency="medium">
       <description></description>
       <url>https://github.com/SpacingBat3/WebCord/releases/tag/v4.10.4</url>

--- a/vitamins/run.sh
+++ b/vitamins/run.sh
@@ -32,4 +32,4 @@ if [[ -f "$WINDOWSTATE" ]]; then
     fi
 fi
 
-env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.github.spacingbat3.webcord}" zypak-wrapper /app/bin/webcord/usr/bin/webcord $FLAGS "$@"
+env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.github.spacingbat3.webcord}" zypak-wrapper /app/bin/webcord/webcord $FLAGS "$@"


### PR DESCRIPTION
Only `/usr/lib/webcord` is necessary for the app to function, as with pretty much any Electron app. Therefore it should be safe to delete everything else to save a bit of space. This also fixes the launch issue on 4.11.0 as `bin/webcord` on that build is no longer a wrapper script like the old build was.

Also bump the Electron base image to 24.08.