### PR TITLE
Update the runtime version from 24.08 to 25.08, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ flatpak install io.github.spacingbat3.webcord
 ## Building it from sources
 Install the build deps:
 ```
-flatpak install flathub org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08
+flatpak install flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
 flatpak install flathub org.electronjs.Electron2.BaseApp
 ```
 

--- a/io.github.spacingbat3.webcord.yml
+++ b/io.github.spacingbat3.webcord.yml
@@ -1,8 +1,8 @@
 app-id: io.github.spacingbat3.webcord
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: "25.08"
 base: org.electronjs.Electron2.BaseApp
-base-version: "24.08"
+base-version: "25.08"
 sdk: org.freedesktop.Sdk
 command: run.sh
 separate-locales: false

--- a/vitamins/io.github.spacingbat3.webcord.metainfo.xml
+++ b/vitamins/io.github.spacingbat3.webcord.metainfo.xml
@@ -8,7 +8,22 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MIT</project_license>
 
-  <developer_name>Contributors of WebCord</developer_name>
+  <url type="homepage">https://github.com/SpacingBat3/WebCord</url>
+  <url type="bugtracker">https://github.com/SpacingBat3/WebCord/issues</url>
+  <url type="vcs-browser">https://github.com/SpacingBat3/WebCord</url>
+  <url type="translate">https://hosted.weblate.org/engage/webcord/</url>
+  <launchable type="desktop-id">io.github.spacingbat3.webcord.desktop</launchable>
+  <developer id="io.github.spacingbat3">
+    <name>Contributors of WebCord</name>
+  </developer>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+    <content_attribute id="money-purchasing">intense</content_attribute>
+  </content_rating>
 
   <supports>
     <control>pointing</control>
@@ -29,19 +44,9 @@
   <screenshots>
     <screenshot type="default">
       <caption>About page</caption>
-      <image>https://i.postimg.cc/sDpv6zcM/image.png</image>
+      <image>https://imgproxy.flathub.org/insecure/dpr:2/f:avif/rs:fill-down/aHR0cHM6Ly9kbC5mbGF0aHViLm9yZy9tZWRpYS9pby9naXRodWIvc3BhY2luZ2JhdDMud2ViY29yZC8xZmU5NWQ3MTIwMDkyYmVlOGMwNDczYzRkZjk2OWNlYy9zY3JlZW5zaG90cy9pbWFnZS0xX29yaWcucG5n</image>
     </screenshot>
   </screenshots>
-
-  <launchable type="desktop-id">io.github.spacingbat3.webcord.desktop</launchable>
-
-  <content_rating type="oars-1.1">
-    <content_attribute id="social-chat">intense</content_attribute>
-    <content_attribute id="social-info">intense</content_attribute>
-    <content_attribute id="social-audio">intense</content_attribute>
-    <content_attribute id="social-contacts">intense</content_attribute>
-    <content_attribute id="money-purchasing">intense</content_attribute>
-  </content_rating>
 
   <releases>
     <release version="4.13.0" date="2026-04-06" urgency="medium">
@@ -624,8 +629,4 @@
 
     </release>
   </releases>
-
-  <url type="homepage">https://github.com/SpacingBat3/WebCord</url>
-  <url type="bugtracker">https://github.com/SpacingBat3/WebCord/issues</url>
-  <url type="translate">https://hosted.weblate.org/engage/webcord/</url>
 </component>


### PR DESCRIPTION
- Update the runtime version to 25.08
- Update README.md file
- Improve the appdata file and group important tags together

The `postimg.cc` domain was restricted in my country. I switched to the Flathub version of the image to bypass the build stopping at the `Running appstreamcli compose` stage.
